### PR TITLE
Configuration for adapter instantiation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <gpg.plugin.version>3.1.0</gpg.plugin.version>
         <javadoc.plugin.version>3.6.3</javadoc.plugin.version>
         <source.plugin.version>3.3.0</source.plugin.version>
+        <spring-boot-configuration-processor.version>3.3.3</spring-boot-configuration-processor.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
-            <version>3.3.3</version>
+            <version>${spring-boot-configuration-processor.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <codexio.requery.version>1.0.4</codexio.requery.version>
+        <codexio.requery.version>1.0.5</codexio.requery.version>
 
         <maven.compiler.version>3.12.1</maven.compiler.version>
         <nexus.plugin.version>1.6.13</nexus.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>requery-core</artifactId>
             <version>${codexio.requery.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+            <version>3.3.3</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/bg/codexio/springframework/boot/AdapterProperties.java
+++ b/src/main/java/bg/codexio/springframework/boot/AdapterProperties.java
@@ -1,0 +1,19 @@
+package bg.codexio.springframework.boot;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "codexio.requery.adapters")
+public class AdapterProperties {
+
+    private List<String> active;
+
+    public List<String> getActive() {
+        return active;
+    }
+
+    public void setActive(List<String> active) {
+        this.active = active;
+    }
+}

--- a/src/main/java/bg/codexio/springframework/boot/FilterJsonAutoConfiguration.java
+++ b/src/main/java/bg/codexio/springframework/boot/FilterJsonAutoConfiguration.java
@@ -1,6 +1,7 @@
 package bg.codexio.springframework.boot;
 
 import bg.codexio.springframework.data.jpa.requery.adapter.HttpFilterAdapter;
+import bg.codexio.springframework.data.jpa.requery.adapter.JsonHttpFilterAdapter;
 import bg.codexio.springframework.data.jpa.requery.config.FilterJsonTypeConverter;
 import bg.codexio.springframework.data.jpa.requery.config.FilterJsonTypeConverterImpl;
 import bg.codexio.springframework.data.jpa.requery.resolver.FilterJsonArgumentResolver;
@@ -20,6 +21,11 @@ public class FilterJsonAutoConfiguration {
     @ConditionalOnMissingBean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
+    }
+
+    @Bean
+    public HttpFilterAdapter httpFilterAdapter() {
+        return new JsonHttpFilterAdapter(objectMapper());
     }
 
     @Bean

--- a/src/main/java/bg/codexio/springframework/boot/FilterJsonAutoConfiguration.java
+++ b/src/main/java/bg/codexio/springframework/boot/FilterJsonAutoConfiguration.java
@@ -1,14 +1,19 @@
 package bg.codexio.springframework.boot;
 
+import bg.codexio.springframework.data.jpa.requery.adapter.HttpFilterAdapter;
 import bg.codexio.springframework.data.jpa.requery.config.FilterJsonTypeConverter;
 import bg.codexio.springframework.data.jpa.requery.config.FilterJsonTypeConverterImpl;
 import bg.codexio.springframework.data.jpa.requery.resolver.FilterJsonArgumentResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
+@EnableConfigurationProperties
 public class FilterJsonAutoConfiguration {
 
     @Bean
@@ -23,13 +28,26 @@ public class FilterJsonAutoConfiguration {
     }
 
     @Bean
+    public AdapterProperties adapterProperties() {
+        return new AdapterProperties();
+    }
+
+    @Bean
+    public RequeryProperties requeryProperties(List<HttpFilterAdapter> availableAdapters) {
+        return new RequeryProperties(
+                adapterProperties(),
+                availableAdapters
+        );
+    }
+
+    @Bean
     public FilterJsonArgumentResolver filterJsonArgumentResolver(
-            ObjectMapper objectMapper,
+            RequeryProperties requeryProperties,
             FilterJsonTypeConverter converter
     ) {
         return new FilterJsonArgumentResolver(
-                objectMapper,
-                converter
+                converter,
+                requeryProperties.getActiveAdapters()
         );
     }
 }

--- a/src/main/java/bg/codexio/springframework/boot/RequeryProperties.java
+++ b/src/main/java/bg/codexio/springframework/boot/RequeryProperties.java
@@ -1,0 +1,34 @@
+package bg.codexio.springframework.boot;
+
+import bg.codexio.springframework.data.jpa.requery.adapter.HttpFilterAdapter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RequeryProperties {
+    private final List<HttpFilterAdapter> activeAdapters;
+
+    public RequeryProperties(
+            AdapterProperties adapters,
+            List<HttpFilterAdapter> availableAdapters
+    ) {
+        if (adapters.getActive() == null || adapters.getActive()
+                                                    .isEmpty()) {
+            this.activeAdapters = availableAdapters;
+        } else {
+            this.activeAdapters = availableAdapters.stream()
+                                                   .filter(adapter -> adapters.getActive()
+                                                                              .contains(adapter.getClass()
+                                                                                               .getSimpleName()))
+                                                   .collect(Collectors.toList());
+        }
+    }
+
+    public List<HttpFilterAdapter> getActiveAdapters() {
+        return this.activeAdapters;
+    }
+
+}
+

--- a/src/main/java/bg/codexio/springframework/boot/RequeryProperties.java
+++ b/src/main/java/bg/codexio/springframework/boot/RequeryProperties.java
@@ -1,6 +1,8 @@
 package bg.codexio.springframework.boot;
 
 import bg.codexio.springframework.data.jpa.requery.adapter.HttpFilterAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -8,6 +10,8 @@ import java.util.stream.Collectors;
 
 @Component
 public class RequeryProperties {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private final List<HttpFilterAdapter> activeAdapters;
 
     public RequeryProperties(
@@ -23,6 +27,13 @@ public class RequeryProperties {
                                                                               .contains(adapter.getClass()
                                                                                                .getSimpleName()))
                                                    .collect(Collectors.toList());
+        }
+        for (var activeAdapter : this.activeAdapters) {
+            this.logger.info(
+                    "{} has been registered as an active adapter",
+                    activeAdapter.getClass()
+                                 .getSimpleName()
+            );
         }
     }
 

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,3 @@
-bg.codexio.springframework.data.jpa.requery.adapter.JsonHttpFilterAdapter
 bg.codexio.springframework.boot.FilterJsonAutoConfiguration
 bg.codexio.springframework.boot.FilterJsonArgumentResolverConfiguration
 bg.codexio.springframework.boot.PrimaryKeyProviderAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
+bg.codexio.springframework.data.jpa.requery.adapter.JsonHttpFilterAdapter
 bg.codexio.springframework.boot.FilterJsonAutoConfiguration
 bg.codexio.springframework.boot.FilterJsonArgumentResolverConfiguration
 bg.codexio.springframework.boot.PrimaryKeyProviderAutoConfiguration


### PR DESCRIPTION
Added:
- default configuration for instantiation and usage of JsonHttpFilterAdapter
- (optional) properties configuration for which adapters to be active
- possibility to create custom implementations of the HttpFilterAdapter interface